### PR TITLE
Feature: Configurable Retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Argus is a lightweight and efficient uptime monitoring service written in Go. It
 
 ## Features
 
-- ✅ Periodic URL monitoring
-- ✅ Response time measurement
-- ✅ Logs URL status (up or down) with error details
-- ✅ Customizable monitoring intervals
-- ✅ Lightweight and fast
-- ✅ Easy to extend and deploy
+- [x] Periodic URL monitoring
+- [x] Response time measurement
+- [x] Logs URL status (up or down) with error details
+- [x] Customizable monitoring intervals
+- [x] Lightweight and fast
+- [x] Easy to extend and deploy
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Argus 🕵️‍♂️
 
+![Docker Image Version](https://img.shields.io/docker/v/tejastn10/argus)
 [![Docker Pulls](https://img.shields.io/docker/pulls/tejastn10/argus)](https://hub.docker.com/r/tejastn10/argus)
+![Docker Image Size](https://img.shields.io/docker/image-size/tejastn10/argus)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/tejastn10/argus)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/tejastn10/argus/docker-image.yml)
 
 Argus is a lightweight and efficient uptime monitoring service written in Go. It periodically checks the availability and response time of a given URL and logs the results. Designed with simplicity, reliability, and extensibility in mind, Argus is a great starting point for developers looking to monitor service health.
 

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -69,6 +69,8 @@ func LogMessage(level, message string) {
 		levelColor = color.New(color.FgYellow)
 	case "ERROR":
 		levelColor = color.New(color.FgRed)
+	case "FATAL":
+		levelColor = color.New(color.FgHiRed)
 	default:
 		levelColor = color.New(color.FgWhite)
 	}
@@ -116,6 +118,12 @@ func Warning(message string) {
 // Error logs error messages
 func Error(err error) {
 	LogMessage("ERROR", err.Error())
+}
+
+// Fatal logs fatal messages and exits the process
+func Fatal(message string) {
+	LogMessage("FATAL", message)
+	os.Exit(1)
 }
 
 // getTimestamp returns the current timestamp as a string in the format YYYY-MM-DD HH:MM:SS

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ func main() {
 	logTimestamp := flag.Bool("logTimeStamp", true, "Set to true to log timestamps. Timestamps are logged by default in the file")
 	url := flag.String("url", "https://example.com", "The URL to monitor. Default is https://example.com")
 	interval := flag.Int("interval", 30, "The monitoring interval in seconds. Default is 30 seconds")
+	retryCount := flag.Int("retryCount", 3, "The number of retries for monitoring requests. Default is 3 retries")
+	backoffDuration := flag.Int("backoffDuration", 2, "The backoff duration (in seconds) between retries. Default is 2 seconds")
 
 	// Parse the flags
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -15,11 +15,21 @@ func main() {
 	logTimestamp := flag.Bool("logTimeStamp", true, "Set to true to log timestamps. Timestamps are logged by default in the file")
 	url := flag.String("url", "https://example.com", "The URL to monitor. Default is https://example.com")
 	interval := flag.Int("interval", 30, "The monitoring interval in seconds. Default is 30 seconds")
-	retryCount := flag.Int("retryCount", 3, "The number of retries for monitoring requests. Default is 3 retries")
-	backoffDuration := flag.Int("backoffDuration", 2, "The backoff duration (in seconds) between retries. Default is 2 seconds")
+	retryCount := flag.Int("retryCount", 3, "The number of retries for monitoring requests. Must be >= 3. Default is 3 retries")
+	backoffDuration := flag.Int("backoffDuration", 3, "The backoff duration (in seconds) between retries. Must be >= 3. Default is 3 seconds")
 
 	// Parse the flags
 	flag.Parse()
+
+	// Validate and enforce minimum values for retryCount and backoffDuration
+	if *retryCount < 3 {
+		logs.Warning("Invalid retryCount provided. Enforcing minimum value of 3.")
+		*retryCount = 3
+	}
+	if *backoffDuration < 3 {
+		logs.Warning("Invalid backoffDuration provided. Enforcing minimum value of 3 seconds.")
+		*backoffDuration = 3
+	}
 
 	// Initialize logger with a timestamp
 	logs.Init(*logToFile, *logTimestamp)

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ func main() {
 	logs.Init(*logToFile, *logTimestamp)
 
 	// Log the start of the monitoring process
-	logs.Info(fmt.Sprintf("Starting uptime monitoring for %s every %v seconds", *url, *interval))
+	logs.Info(fmt.Sprintf("Starting uptime monitoring for %s every %v seconds with %d retries and %d seconds backoff duration",
+		*url, *interval, *retryCount, *backoffDuration))
 
 	// Monitoring loop
 	for {

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -76,7 +76,7 @@ func MonitorURL(urlString string, retryCount int, initialBackoff time.Duration) 
 
 		// Exponential backoff logic
 		backoffDuration := initialBackoff * time.Duration(1<<uint(attempt-1)) // Exponential backoff
-		logs.Warning(fmt.Sprintf("Backoff before retrying... Attempt %d of %d. Waiting for %v", attempt, retryCount, backoffDuration))
+		logs.Warning(fmt.Sprintf("Backoff before retrying... Attempt %d of %d. Waiting for %v. Error: %v", attempt, retryCount, backoffDuration, lastError))
 		time.Sleep(backoffDuration)
 	}
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -3,11 +3,12 @@ package monitor
 import (
 	"net/http"
 	"testing"
+	"time"
 )
 
-// TestCheckURLTable tests the CheckURL function using a table-driven approach.
+// TestMonitorURLTable tests the MonitorURL function using a table-driven approach.
 // Each test case specifies a URL, the expected status code, and whether an error is expected.
-func TestCheckURLTable(t *testing.T) {
+func TestMonitorURLTable(t *testing.T) {
 	tests := []struct {
 		name       string // Name of the test case
 		url        string // URL to test
@@ -22,12 +23,12 @@ func TestCheckURLTable(t *testing.T) {
 	for _, tt := range tests {
 		// Run each test case as a sub-test
 		t.Run(tt.name, func(t *testing.T) {
-			// Call the CheckURL function with the test case URL
-			statusCode, _, err := CheckURL(tt.url)
+			// Call the MonitorURL function with the test case URL
+			statusCode, _, err := MonitorURL(tt.url, 3, 2*time.Second)
 
 			// Check if the error behavior matches the expectation
 			if (err != nil) != tt.wantErr {
-				t.Errorf("CheckURL() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("MonitorURL() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			// Verify the returned status code, but only if no error is expected


### PR DESCRIPTION
# Description

This pull request introduces retry logic with exponential backoff, ensuring more robust handling of failed URL monitoring attempts. The retry count and backoff duration can be configured through flags. Additionally, the `logs` package has been updated to include a new fatal log, allowing for more granular logging of fatal errors. The README has been updated to display multiple, proper badges for better project status visibility.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes locally
- [x] I have added appropriate documentation or updated existing documentation
- [x] My code follows the project's coding conventions and style guidelines
- [x] All new and existing tests passed locally
- [x] I have reviewed my own code and ensured it is ready for review

## Additional Notes

- The retry logic uses exponential backoff to help manage request failures and reduce the strain on the monitored services.
- The new fatal log provides a way to handle critical issues that require immediate attention.

> [!WARNING]  
> Exponential backoff may increase the wait time between retries significantly, especially if the retry count is high. Ensure that you have configured it appropriately for your use case.