### PR TITLE
fix: add multiple platforms in github action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,windows/amd64,darwin/amd64 # Build for multiple platforms
           tags: |
             tejastn10/argus:latest
             tejastn10/argus:${{ github.ref_name }}


### PR DESCRIPTION
# Description

This pull request updates the GitHub Actions workflow to support building Docker images for multiple platforms, including `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `windows/amd64`, and `darwin/amd64`. This ensures that the image can be built and deployed for all major platforms.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested my changes locally
- [x] I have added appropriate documentation or updated existing documentation
- [x] My code follows the project's coding conventions and style guidelines
- [x] All new and existing tests passed locally
- [x] I have reviewed my own code and ensured it is ready for review

## Additional Notes

This change ensures that the Docker image is compatible with a wide range of platforms and can be built and published without issues on all major architectures.